### PR TITLE
CI: arch symbol matrix to guard fallback/native variant wiring

### DIFF
--- a/.github/scripts/check_arch_symbols.py
+++ b/.github/scripts/check_arch_symbols.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Confirm the static archive contains exactly the optimized variant
+implementations the configured feature flags imply -- no more, no less.
+
+Deterministic and self-deriving: it reads the build's active compile-definition
+set (zlib-ng prints it as "CURRENT_SOURCE_DIR: ...") and a declarative
+feature -> symbol map below. For every mapped feature:
+
+  * feature enabled  -> its symbol(s) MUST be defined in the archive
+  * feature disabled -> its symbol(s) MUST NOT be defined (dead/wrong variant)
+
+It also asserts capability liveness: each capability has >=1 implementation
+symbol (the library can never be left with no crc32/adler32/... at all).
+
+Generic-fallback presence (crc32_braid, adler32_c, ...) is config-and-arch
+dependent (e.g. LoongArch CRC is base-ISA so braid must be absent); that is
+NOT guessed here. Pass verified per-config expectations via --expect/--forbid.
+
+Usage: check_arch_symbols.py <build_dir> [nm] [--expect a,b] [--forbid x,y]
+"""
+import glob, re, subprocess, sys
+
+# feature compile-definition -> optimized variant symbols it must produce.
+# Keys are the macros zlib-ng emits in its "CURRENT_SOURCE_DIR:" line; values
+# taken from the prototype guards in arch/*/*_functions.h.
+FEATURE_SYMS = {
+    # x86
+    "X86_SSE2":            ["compare256_sse2", "slide_hash_sse2", "chunkmemset_safe_sse2"],
+    "X86_SSSE3":           ["adler32_ssse3", "chunkmemset_safe_ssse3"],
+    "X86_SSE42":           ["adler32_copy_sse42"],
+    "X86_PCLMULQDQ_CRC":   ["crc32_pclmulqdq", "crc32_copy_pclmulqdq"],
+    "X86_AVX2":            ["adler32_avx2", "compare256_avx2", "slide_hash_avx2", "chunkmemset_safe_avx2"],
+    "X86_AVX512":          ["adler32_avx512", "compare256_avx512", "chunkmemset_safe_avx512"],
+    "X86_AVX512VNNI":      ["adler32_avx512_vnni"],
+    "X86_VPCLMULQDQ_AVX2": ["crc32_vpclmulqdq_avx2"],
+    "X86_VPCLMULQDQ_AVX512": ["crc32_vpclmulqdq_avx512"],
+    # arm (macro names confirmed from CI "CURRENT_SOURCE_DIR: ... ARM_*")
+    "ARM_NEON":            ["adler32_neon", "compare256_neon", "slide_hash_neon"],
+    "ARM_CRC32":           ["crc32_armv8"],
+    "ARM_PMULL_EOR3":      ["crc32_armv8_pmull_eor3"],
+    # power / s390 / riscv / loongarch: the emitted compile-def names are not
+    # yet confirmed from a real run, so they are intentionally omitted to avoid
+    # false assertions. Capability-liveness still applies on those arches; add
+    # verified entries here once captured from a green run's cfg artifact.
+}
+# any zlib-ng arch/fallback implementation symbol (for the "found" report)
+ARCH_SYM = re.compile(
+    r"^(crc32_(braid|chorba\w*|pclmulqdq|vpclmulqdq\w*|armv8\w*|power8|"
+    r"s390_vx|riscv64_zbc|loongarch64)|adler32_(c|ssse3|sse42|avx2|avx512\w*|"
+    r"neon|vmx|power8|rvv|lsx)|compare256_\w+|longest_match\w*|"
+    r"slide_hash_\w+|chunkmemset_safe_\w+|inflate_fast_\w+)$"
+)
+
+# every build must define at least one implementation per capability
+CAPABILITIES = {
+    "crc32":      re.compile(r"^crc32_(braid|chorba|pclmulqdq|vpclmulqdq|armv8|power8|s390_vx|riscv64_zbc|loongarch64)"),
+    "adler32":    re.compile(r"^adler32_(c|ssse3|avx2|avx512|neon|vmx|power8|rvv|lsx)"),
+    "compare256": re.compile(r"^compare256_"),
+    "slide_hash": re.compile(r"^slide_hash_"),
+}
+
+def sh(a):
+    try: return subprocess.run(a, capture_output=True, text=True).stdout
+    except FileNotFoundError: return ""
+
+def lst(flag):
+    return ({s for s in re.split(r"[,\s]+", sys.argv[sys.argv.index(flag)+1]) if s}
+            if flag in sys.argv else set())
+
+def main():
+    build = sys.argv[1]
+    nmbin = sys.argv[2] if len(sys.argv) > 2 and not sys.argv[2].startswith("-") else "nm"
+    if subprocess.run(["which", nmbin], capture_output=True).returncode: nmbin = "nm"
+    expect, forbid = lst("--expect"), lst("--forbid")
+
+    cfg = glob.glob(f"{build}/**/.cfg.log", recursive=True) + [f"{build}/.cfg.log"]
+    log = ""
+    for c in cfg:
+        try: log = open(c).read(); break
+        except OSError: continue
+    m = re.search(r"CURRENT_SOURCE_DIR:\s*(.+)", log)
+    feats = set(m.group(1).split()) if m else set()
+    if not feats:
+        print("::warning::could not read active feature set; skipping derived checks")
+
+    ars = (glob.glob(f"{build}/**/libz-ng.a", recursive=True)
+           or glob.glob(f"{build}/**/libz.a", recursive=True))
+    if not ars:
+        print(f"::error::no static archive under {build}"); return 1
+    archive = ars[0]
+    defined = {ln.split()[-1].lstrip("_")
+               for ln in sh([nmbin, "--defined-only", archive]).splitlines()
+               if len(ln.split()) >= 2 and ln.split()[-2] in ("T", "t")}
+    # *_stub are functable dispatch shims, not implementations; functable.c
+    # guards them with #ifndef DISABLE_RUNTIME_CPU_DETECTION, so they exist
+    # iff runtime CPU detection is on. Keep them out of impl/liveness checks.
+    stubs = sorted(s for s in defined if s.endswith("_stub"))
+    impl = {s for s in defined if not s.endswith("_stub")}
+    found = sorted(s for s in impl if ARCH_SYM.match(s))
+    mapped = sorted(f for f in feats if f in FEATURE_SYMS)
+    print(f"archive {archive}: {len(defined)} defined symbols")
+    print("enabled features:")
+    for f in mapped or ["(none mapped)"]:
+        print(f"  {f}")
+    print(f"arch implementation symbols found ({len(found)}):")
+    for s in found:
+        print(f"  {s}")
+
+    rc = 0
+    def fail(msg):
+        nonlocal rc
+        print(f"::error::{msg}")
+        rc = 1
+
+    # derived: enabled feature => present; mapped-but-disabled => absent
+    for feat, syms in FEATURE_SYMS.items():
+        on = feat in feats
+        for s in syms:
+            if on and s not in defined:
+                fail(f"{feat} enabled but '{s}' not in archive")
+            if not on and s in defined:
+                fail(f"{feat} disabled but '{s}' present (wrong/dead variant)")
+
+    # capability liveness (a stub is a shim, not an implementation)
+    for cap, rx in CAPABILITIES.items():
+        if not any(rx.match(s) for s in impl):
+            fail(f"no '{cap}' implementation compiled into the archive")
+
+    # functable stubs exist iff runtime CPU detection is on
+    runtime_on = "DISABLE_RUNTIME_CPU_DETECTION" not in feats
+    print(f"runtime CPU detection: {'on' if runtime_on else 'off'}; "
+          f"{len(stubs)} *_stub symbols")
+    if not runtime_on and stubs:
+        fail("DISABLE_RUNTIME_CPU_DETECTION set but *_stub symbols present: "
+             + " ".join(stubs))
+    elif runtime_on and not stubs:
+        # static stubs may be absent if the archive carries no local symbols
+        # (stripped / nm without locals), so warn rather than hard-fail.
+        print("::warning::runtime CPU detection on but no *_stub symbols found "
+              "(stripped archive, or functable not built?)")
+
+    # explicit verified per-config overrides
+    for s in sorted(expect - defined): fail(f"expected '{s}' absent")
+    for s in sorted(forbid & defined): fail(f"forbidden '{s}' present")
+
+    if rc == 0:
+        print("OK")
+    return rc
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_native_dispatch.py
+++ b/.github/scripts/check_native_dispatch.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Confirm the native_* dispatch macros resolve to the correct implementation
+under DISABLE_RUNTIME_CPU_DETECTION (catches the macro-redefinition / silent
+wrong-dispatch class, e.g. native_crc32 ending up crc32_chorba instead of
+crc32_chorba_sse41).
+
+Pure preprocessor: a probe TU emits each native_* expansion and which
+compile-time *_NATIVE feature macros are set, via #pragma message. Compiled
+-fsyntax-only with the target compiler -> cross-safe, no link, no qemu.
+
+Expected value = first implementation in the capability's dispatch-priority
+list whose gating *_NATIVE macro is set, else the generic fallback. Priority
+is the documented zlib-ng preference; x86/arm are encoded (verified); other
+arches are report-only (printed, not asserted) until verified.
+
+Usage: check_native_dispatch.py <src> <build_dir> <cc> [extra cc flags...]
+"""
+import json, os, re, subprocess, sys, tempfile
+
+# capability -> ordered [(gating *_NATIVE macro, expected symbol)], best first;
+# final entry's macro None = the generic fallback when nothing above matched.
+# Per-arch dispatch rules taken verbatim from each arch/*/*_functions.h
+# `#ifdef *_NATIVE -> #define native_crc32 ...` block (best first). Only one
+# arch's *_NATIVE macros can be set in a build, so cross-arch entries coexist.
+PRIORITY = {
+    "native_crc32": [
+        ("X86_VPCLMULQDQ_AVX512_NATIVE", "crc32_vpclmulqdq_avx512"),
+        ("X86_VPCLMULQDQ_AVX2_NATIVE",   "crc32_vpclmulqdq_avx2"),
+        ("X86_PCLMULQDQ_NATIVE",         "crc32_pclmulqdq"),
+        ("X86_SSE41_NATIVE",             "crc32_chorba_sse41"),
+        ("X86_SSE2_NATIVE",              "crc32_chorba_sse2"),
+        ("ARM_PMULL_EOR3_NATIVE",        "crc32_armv8_pmull_eor3"),
+        ("ARM_CRC32_NATIVE",             "crc32_armv8"),
+        ("POWER8_VSX_CRC32_NATIVE",      "crc32_power8"),
+        ("S390_VX_NATIVE",               "crc32_s390_vx"),
+        ("RISCV_ZBC_NATIVE",             "crc32_riscv64_zbc"),
+        ("LOONGARCH_CRC_NATIVE",         "crc32_loongarch64"),
+    ],
+    "native_crc32_copy": [
+        ("X86_VPCLMULQDQ_AVX512_NATIVE", "crc32_copy_vpclmulqdq_avx512"),
+        ("X86_VPCLMULQDQ_AVX2_NATIVE",   "crc32_copy_vpclmulqdq_avx2"),
+        ("X86_PCLMULQDQ_NATIVE",         "crc32_copy_pclmulqdq"),
+        ("X86_SSE41_NATIVE",             "crc32_copy_chorba_sse41"),
+        ("X86_SSE2_NATIVE",              "crc32_copy_chorba_sse2"),
+        ("ARM_PMULL_EOR3_NATIVE",        "crc32_copy_armv8_pmull_eor3"),
+        ("ARM_CRC32_NATIVE",             "crc32_copy_armv8"),
+        ("POWER8_VSX_CRC32_NATIVE",      "crc32_copy_power8"),
+        ("S390_VX_NATIVE",               "crc32_copy_s390_vx"),
+        ("RISCV_ZBC_NATIVE",             "crc32_copy_riscv64_zbc"),
+    ],
+    "native_adler32": [
+        ("X86_AVX512VNNI_NATIVE", "adler32_avx512_vnni"),
+        ("X86_AVX512_NATIVE",     "adler32_avx512"),
+        ("X86_AVX2_NATIVE",       "adler32_avx2"),
+        ("X86_SSSE3_NATIVE",      "adler32_ssse3"),
+        ("ARM_NEON_NATIVE",       "adler32_neon"),
+        ("POWER8_VSX_NATIVE",     "adler32_power8"),
+        ("PPC_VMX_NATIVE",        "adler32_vmx"),
+        ("RISCV_RVV_NATIVE",      "adler32_rvv"),
+        ("LOONGARCH_LASX_NATIVE", "adler32_lasx"),
+        ("LOONGARCH_LSX_NATIVE",  "adler32_lsx"),
+    ],
+    "native_adler32_copy": [
+        ("X86_AVX512VNNI_NATIVE", "adler32_copy_avx512_vnni"),
+        ("X86_AVX512_NATIVE",     "adler32_copy_avx512"),
+        ("X86_AVX2_NATIVE",       "adler32_copy_avx2"),
+        ("X86_SSE42_NATIVE",      "adler32_copy_sse42"),
+        ("X86_SSSE3_NATIVE",      "adler32_copy_ssse3"),
+    ],
+    # x86 SIMD tiers verified from arch/x86/x86_functions.h; non-x86 SIMD
+    # priority is a follow-up (relies on the generic-clobber check below).
+    "native_chunkmemset_safe": [
+        ("X86_AVX512_NATIVE", "chunkmemset_safe_avx512"),
+        ("X86_AVX2_NATIVE",   "chunkmemset_safe_avx2"),
+        ("X86_SSSE3_NATIVE",  "chunkmemset_safe_ssse3"),
+        ("X86_SSE2_NATIVE",   "chunkmemset_safe_sse2"),
+    ],
+    "native_compare256": [
+        ("X86_AVX512_NATIVE", "compare256_avx512"),
+        ("X86_AVX2_NATIVE",   "compare256_avx2"),
+        ("X86_SSE2_NATIVE",   "compare256_sse2"),
+    ],
+    "native_inflate_fast": [
+        ("X86_AVX512_NATIVE", "inflate_fast_avx512"),
+        ("X86_AVX2_NATIVE",   "inflate_fast_avx2"),
+        ("X86_SSSE3_NATIVE",  "inflate_fast_ssse3"),
+        ("X86_SSE2_NATIVE",   "inflate_fast_sse2"),
+    ],
+    "native_longest_match": [
+        ("X86_AVX512_NATIVE", "longest_match_avx512"),
+        ("X86_AVX2_NATIVE",   "longest_match_avx2"),
+        ("X86_SSE2_NATIVE",   "longest_match_sse2"),
+    ],
+    "native_longest_match_roll": [
+        ("X86_AVX512_NATIVE", "longest_match_roll_avx512"),
+        ("X86_AVX2_NATIVE",   "longest_match_roll_avx2"),
+        ("X86_SSE2_NATIVE",   "longest_match_roll_sse2"),
+    ],
+    "native_slide_hash": [
+        ("X86_AVX2_NATIVE", "slide_hash_avx2"),
+        ("X86_SSE2_NATIVE", "slide_hash_sse2"),
+    ],
+}
+# when no mapped arch native is enabled, native_* must be a generic fallback
+GENERIC = {
+    "native_crc32":             {"crc32_braid", "crc32_chorba"},
+    "native_crc32_copy":        {"crc32_copy_braid", "crc32_copy_chorba"},
+    "native_adler32":           {"adler32_c"},
+    "native_adler32_copy":      {"adler32_copy_c"},
+    "native_chunkmemset_safe":  {"chunkmemset_safe_c"},
+    "native_compare256":        {"compare256_c"},
+    "native_inflate_fast":      {"inflate_fast_c"},
+    "native_longest_match":     {"longest_match_c"},
+    "native_longest_match_roll":{"longest_match_roll_c"},
+    "native_slide_hash":        {"slide_hash_c"},
+}
+# *_NATIVE macros the probe should report (all gating macros above)
+NATIVE_MACROS = sorted({m for lst in PRIORITY.values() for m, _ in lst})
+ASSERT_CAPS = tuple(PRIORITY)
+
+def main():
+    src, build, cc = sys.argv[1], sys.argv[2], sys.argv[3]
+    extra = sys.argv[4:]
+
+    # Mirror the real dispatch TU exactly: take the actual compile flags
+    # zlib-ng uses for a core C file (functable.c includes arch_functions.h and
+    # is built with the global flags, not per-file ISA flags) from
+    # compile_commands.json. This captures -march/-D/-I for any combo.
+    cc_json = f"{build}/compile_commands.json"
+    try:
+        entries = json.load(open(cc_json))
+    except OSError:
+        print(f"::error::{cc_json} missing; configure with "
+              "-D CMAKE_EXPORT_COMPILE_COMMANDS=ON")
+        return 1
+    ent = next((e for e in entries if re.search(r"/(functable|crc32|deflate)\.c$",
+               e["file"])), None)
+    if not ent:
+        print("::error::no core C TU in compile_commands.json")
+        return 1
+    args = ent.get("arguments") or ent["command"].split()
+    # keep every flag verbatim (so -march/-arch/-target/-isysroot/-D/-I all
+    # carry over and the probe mirrors the real TU); drop only output/dep/source.
+    keep = []
+    skip_next = False
+    for a in args[1:]:
+        if skip_next:
+            skip_next = False; continue
+        if a in ("-o", "-MT", "-MF", "-MQ"):
+            skip_next = True; continue
+        if a in ("-c", "-MD", "-MMD") or a.endswith((".c", ".o", ".obj")):
+            continue
+        keep.append(a)
+    defs = keep
+    if "-DDISABLE_RUNTIME_CPU_DETECTION" not in keep:
+        print("runtime CPU detection on -> native_* not macro-dispatched; skip")
+        return 0
+
+    caps = list(PRIORITY)
+    probe = "#include \"zbuild.h\"\n#include \"arch_functions.h\"\n" \
+            "#define S2(x) #x\n#define S(x) S2(x)\n"
+    for cp in caps:
+        probe += f"#ifdef {cp}\n#pragma message(\"DISP {cp}=\" S({cp}))\n#endif\n"
+    for nm in NATIVE_MACROS:
+        probe += f"#ifdef {nm}\n#pragma message(\"NAT {nm}\")\n#endif\n"
+
+    with tempfile.NamedTemporaryFile("w", suffix=".c", delete=False) as f:
+        f.write(probe); tu = f.name
+    p = subprocess.run([cc, "-fsyntax-only", *defs, *extra,
+                        f"-I{src}", f"-I{build}", tu],
+                       capture_output=True, text=True)
+    out = p.stderr
+    os.unlink(tu)
+
+    # A non-zero compiler exit is the primary signal that the probe TU did not
+    # build (missing generated headers, bad flags). Fail fast here so a real
+    # compile error cannot masquerade as a successful probe.
+    if p.returncode != 0:
+        print("::error::native-dispatch probe failed to compile "
+              f"(returncode {p.returncode}); cannot verify macro resolution")
+        print(out.strip()[-1500:])
+        return 1
+
+    disp = dict(re.findall(r"DISP (native_\w+)=(\w+)", out))
+    natives = set(re.findall(r"NAT (\w+)", out))
+    # Defence in depth: even on a zero exit, a missing DISP set means the probe
+    # produced no #pragma messages -- treat as a harness error.
+    if not disp:
+        print("::error::native-dispatch probe emitted no DISP lines; "
+              "cannot verify macro resolution")
+        print(out.strip()[-1500:])
+        return 1
+    print("compile-time natives:", " ".join(sorted(natives)) or "(none)")
+
+    rc = 0
+    for cp in caps:
+        actual = disp.get(cp, "(undefined)")
+        exp = next((sym for mac, sym in PRIORITY[cp] if mac in natives), None)
+        if exp is None:
+            # No PRIORITY rule matched for the natives present. PRIORITY is
+            # incomplete for non-x86 SIMD caps, so we cannot tell whether an
+            # unmapped arch native (e.g. slide_hash_rvv) is correct or whether
+            # generic here is a clobber. Either way it is NOT a clobber we can
+            # prove (a clobber is caught in the exp-is-not-None path), so this
+            # is informational only -- never an error.
+            gen = GENERIC.get(cp, set())
+            kind = "generic" if actual in gen else "arch native (unverified)"
+            print(f"{cp} = {actual}  [report-only: {kind}]")
+            continue
+        tag = "OK" if actual == exp else "MISMATCH"
+        print(f"{cp} = {actual}  expected {exp}  [{tag}]")
+        if actual != exp and cp in ASSERT_CAPS:
+            print(f"::error::{cp} resolves to '{actual}' but should be '{exp}' "
+                  f"for the configured natives")
+            rc = 1
+    return rc
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/arch-symbols.yml
+++ b/.github/workflows/arch-symbols.yml
@@ -1,0 +1,196 @@
+name: Arch Symbols
+
+# One job per arch (cross toolchain installed once). Within each job a single
+# step iterates that arch's WITH_<feature> combinations: cross-build the static
+# library plus the C++ consumers (gtest_zlib, benchmark_zlib) -- compile and
+# cross-link only, never executed, so no qemu -- then assert the archive symbol
+# table (feature -> symbol map) and native_* macro dispatch per combination.
+# Each combination is reported; a failing one emits a ::error:: annotation and
+# fails the job, but the rest still run.
+
+on:
+  push: { branches: [develop, master, main] }
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  arch-symbols:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x86_64,  cc: gcc,                       triple: x86_64-linux-gnu,      pkg: "",
+              feats: "WITH_SSSE3 WITH_SSE41 WITH_SSE42 WITH_PCLMULQDQ WITH_AVX2 WITH_AVX512 WITH_AVX512VNNI WITH_VPCLMULQDQ",
+              targets: "march-westmere|-D CMAKE_C_FLAGS=-march=westmere -D CMAKE_CXX_FLAGS=-march=westmere;march-x86-64-v4|-D CMAKE_C_FLAGS=-march=x86-64-v4 -D CMAKE_CXX_FLAGS=-march=x86-64-v4;march-icelake-server|-D CMAKE_C_FLAGS=-march=icelake-server -D CMAKE_CXX_FLAGS=-march=icelake-server;allfb-westmere|-D WITH_ALL_FALLBACKS=ON -D CMAKE_C_FLAGS=-march=westmere -D CMAKE_CXX_FLAGS=-march=westmere",
+              extra: "cflags-only-march|-D WITH_RUNTIME_CPU_DETECTION=ON -D CMAKE_C_FLAGS=-march=westmere" }
+          - { arch: aarch64, cc: aarch64-linux-gnu-gcc,     triple: aarch64-linux-gnu,     pkg: "gcc-aarch64-linux-gnu g++-aarch64-linux-gnu",
+              feats: "WITH_NEON WITH_ARMV8 WITH_ACLE",
+              targets: "march-armv8-crc|-D CMAKE_C_FLAGS=-march=armv8-a+crc -D CMAKE_CXX_FLAGS=-march=armv8-a+crc;march-armv8.2-sha3|-D CMAKE_C_FLAGS=-march=armv8.2-a+crypto+sha3 -D CMAKE_CXX_FLAGS=-march=armv8.2-a+crypto+sha3",
+              extra: "cflags-only-march|-D WITH_RUNTIME_CPU_DETECTION=ON -D CMAKE_C_FLAGS=-march=armv8-a+crc" }
+          - { arch: armhf,   cc: arm-linux-gnueabihf-gcc,   triple: arm-linux-gnueabihf,   pkg: "gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf",
+              feats: "WITH_NEON WITH_ARMV6 WITH_ARMV8 WITH_ACLE",
+              targets: "" }
+          - { arch: ppc64le, cc: powerpc64le-linux-gnu-gcc, triple: powerpc64le-linux-gnu, pkg: "gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu",
+              feats: "WITH_ALTIVEC WITH_POWER8 WITH_POWER9",
+              targets: "mcpu-power9|-D CMAKE_C_FLAGS=-mcpu=power9 -D CMAKE_CXX_FLAGS=-mcpu=power9",
+              extra: "cflags-only-march|-D WITH_RUNTIME_CPU_DETECTION=ON -D CMAKE_C_FLAGS=-mcpu=power9" }
+          - { arch: s390x,   cc: s390x-linux-gnu-gcc,       triple: s390x-linux-gnu,       pkg: "gcc-s390x-linux-gnu g++-s390x-linux-gnu",
+              feats: "WITH_S390_VX",
+              targets: "march-z13|-D CMAKE_C_FLAGS=-march=z13 -D CMAKE_CXX_FLAGS=-march=z13",
+              extra: "cflags-only-march|-D WITH_RUNTIME_CPU_DETECTION=ON -D CMAKE_C_FLAGS=-march=z13" }
+          - { arch: riscv64, cc: riscv64-linux-gnu-gcc,     triple: riscv64-linux-gnu,     pkg: "gcc-riscv64-linux-gnu g++-riscv64-linux-gnu",
+              feats: "WITH_RVV WITH_RISCV_ZBC",
+              targets: "march-zbc|-D CMAKE_C_FLAGS=-march=rv64gc_zbc -D CMAKE_CXX_FLAGS=-march=rv64gc_zbc;march-rvv|-D CMAKE_C_FLAGS=-march=rv64gcv -D CMAKE_CXX_FLAGS=-march=rv64gcv",
+              extra: "cflags-only-march|-D WITH_RUNTIME_CPU_DETECTION=ON -D CMAKE_C_FLAGS=-march=rv64gcv" }
+          - { arch: loongarch64, cc: loongarch64-unknown-linux-gnu-gcc, triple: loongarch64-unknown-linux-gnu, pkg: "",
+              tc: "https://github.com/loongson/build-tools/releases/download/2025.02.21/x86_64-cross-tools-loongarch64-binutils_2.44-gcc_14.2.0-glibc_2.41.tar.xz",
+              feats: "WITH_CRC32_LA WITH_LSX WITH_LASX",
+              targets: "march-la464|-D CMAKE_C_FLAGS=-march=la464 -D CMAKE_CXX_FLAGS=-march=la464",
+              extra: "cflags-only-march|-D WITH_RUNTIME_CPU_DETECTION=ON -D CMAKE_C_FLAGS=-march=la464" }
+
+    name: ${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build ${{ matrix.pkg }}
+
+      # Some arches (loongarch64) have no cross toolchain in apt; fetch a
+      # prebuilt one and put its bin on PATH.
+      - name: Fetch prebuilt cross toolchain
+        if: matrix.tc != ''
+        run: |
+          curl -fsSL "${{ matrix.tc }}" -o /tmp/cross.tar.xz
+          mkdir -p "$HOME/cross-tc"
+          tar -xf /tmp/cross.tar.xz -C "$HOME/cross-tc"
+          gcc_path=$(find "$HOME/cross-tc" -type f -name '${{ matrix.cc }}' | head -1)
+          [ -n "$gcc_path" ] || { echo "::error::${{ matrix.cc }} not found in $(basename "${{ matrix.tc }}")"; exit 1; }
+          dirname "$gcc_path" >> "$GITHUB_PATH"
+          "$gcc_path" --version | head -1
+
+      - name: Build + symbol-check every WITH_ combination for ${{ matrix.arch }}
+        env:
+          CC: ${{ matrix.cc }}
+          TRIPLE: ${{ matrix.triple }}
+          FEATS: ${{ matrix.feats }}
+          TARGETS: ${{ matrix.targets }}
+          EXTRA: ${{ matrix.extra }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -uo pipefail
+          # combo name -> extra cmake flags
+          combos=(
+            "runtime|-D WITH_RUNTIME_CPU_DETECTION=ON"
+            "native|-D WITH_RUNTIME_CPU_DETECTION=OFF"
+            "all-fallbacks|-D WITH_RUNTIME_CPU_DETECTION=ON -D WITH_ALL_FALLBACKS=ON"
+            "allfb-native|-D WITH_RUNTIME_CPU_DETECTION=OFF -D WITH_ALL_FALLBACKS=ON"
+          )
+          for f in $FEATS; do combos+=("no-${f#WITH_}|-D ${f}=OFF"); done
+          # feature-targeted native builds (top *_NATIVE enabled)
+          IFS=';' read -ra tc <<< "${TARGETS:-}"
+          for t in "${tc[@]}"; do [ -n "$t" ] && combos+=("${t%%|*}|-D WITH_RUNTIME_CPU_DETECTION=OFF ${t#*|}"); done
+          # verbatim extra combos (e.g. KungFuJesus C-only -march mismatch)
+          IFS=';' read -ra ec <<< "${EXTRA:-}"
+          for e in "${ec[@]}"; do [ -n "$e" ] && combos+=("$e"); done
+
+          fails=""
+          for entry in "${combos[@]}"; do
+            cname=${entry%%|*}; cflags=${entry#*|}
+            bd="build-${cname}"
+            mkdir -p "$bd"
+            echo "::group::${{ matrix.arch }} / ${cname} — configure + build  (${cflags})"
+            ok=1
+            # Google Benchmark probes its regex backend with try_run, which
+            # cannot run under cross-compile; pre-seed the cache so it skips
+            # detection and uses std::regex.
+            cmake -S . -B "$bd" -G Ninja -D CMAKE_C_COMPILER="$CC" \
+                  -D CMAKE_CXX_COMPILER="$(echo "$CC" | sed 's/gcc$/g++/')" \
+                  -D BUILD_SHARED_LIBS=OFF -D BUILD_TESTING=ON -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                  -D WITH_BENCHMARKS=ON -D WITH_GTEST=ON \
+                  -D HAVE_STD_REGEX=ON -D HAVE_POSIX_REGEX=OFF -D HAVE_GNU_POSIX_REGEX=OFF \
+                  -D RUN_HAVE_STD_REGEX=1 -D RUN_HAVE_POSIX_REGEX=0 -D RUN_HAVE_GNU_POSIX_REGEX=0 \
+                  -D WITH_MAINTAINER_WARNINGS=ON $cflags 2>&1 | tee "$bd/.cfg.log" \
+              || { echo "::error::${{ matrix.arch }}/${cname}: cmake configure failed"; fails="$fails ${cname}(configure)"; ok=0; }
+            # build lib + the C++ consumers (compile + cross-link, never run) so
+            # gtest/benchmark compile errors are caught too.
+            if [ $ok = 1 ]; then
+              # -k 0 = ninja keep-going: link gtest_zlib AND benchmark_zlib
+              # even if one fails, so the cflags-only-march xfail shows the
+              # benchmark-link failure (the exact KungFuJesus scenario in
+              # PR#2302) and not just gtest's.
+              cmake --build "$bd" --target zlib-ng gtest_zlib benchmark_zlib \
+                -- -k 0 > "$bd/.build.log" 2>&1 && built=1 || built=0
+              cat "$bd/.build.log"
+              if [ "$cname" = cflags-only-march ]; then
+                # Constraint demonstration: C and C++ must use symmetric ISA
+                # flags. The symmetric 'march-*' target combos prove the
+                # supported path links clean. This combo injects -march into C
+                # only (the KungFuJesus mis-config). It is unsupported by
+                # design; both documented outcomes are accepted:
+                #   - link fails with a missing generic-fallback symbol: the
+                #     desync the C TUs compiled the fallback out while an
+                #     un-flagged C++ consumer still references it. Manifests on
+                #     arches whose consumers cross-reference that symbol
+                #     (x86/arm/riscv with the current benchmarks).
+                #   - links clean: the gated-out fallback is reached only
+                #     through the (consistently -march'd) C functable, so
+                #     nothing crosses the C/C++ boundary (s390/ppc/loongarch).
+                # Only a different failure is a real flag.
+                fb='undefined reference to .(crc32_braid|crc32_copy_braid|crc32_chorba|adler32_c|adler32_copy_c|compare256_c|slide_hash_c|chunkmemset_safe_c|longest_match)'
+                if [ $built = 1 ]; then
+                  echo "${{ matrix.arch }}/${cname}: links clean — asymmetric C-only -march is benign here (the gated-out fallback is not cross-referenced by the C++ consumers on this arch). Symmetric flags are still required in general."
+                elif grep -Eq "$fb" "$bd/.build.log"; then
+                  echo "${{ matrix.arch }}/${cname}: EXPECTED link failure — asymmetric C-only -march is unsupported. The generic fallbacks are compiled out of the library but still referenced by the C++ consumers. Symmetric CMAKE_C_FLAGS/CMAKE_CXX_FLAGS is required."
+                else
+                  echo "::error::${{ matrix.arch }}/${cname}: failed without the expected missing-fallback-symbol signature"
+                  fails="$fails ${cname}(build)"
+                fi
+                ok=0
+              elif [ $built = 0 ]; then
+                echo "::error::${{ matrix.arch }}/${cname}: build failed"
+                fails="$fails ${cname}(build)"; ok=0
+              fi
+            fi
+            echo "::endgroup::"
+            echo "──── ${{ matrix.arch }} / ${cname} — symbol + dispatch check ────"
+            # Floor-respecting check: a pinned high -march build must not carry
+            # below-floor generic *_c / braid / chorba fallbacks; they are
+            # unreachable because the binary requires >= -march at runtime.
+            # SIMD variants gated on WITH_<feat> are independently built and
+            # are not forbidden here.
+            forbid=""
+            case "$cname" in
+              march-westmere|march-icelake-server)
+                # PCLMUL + SSSE3 + SSE2 floor: braid/chorba and *_c all dead.
+                forbid="crc32_braid crc32_copy_braid crc32_chorba crc32_copy_chorba crc32_chorba_sse2 crc32_copy_chorba_sse2 crc32_chorba_sse41 crc32_copy_chorba_sse41 adler32_c adler32_copy_c compare256_c longest_match_c longest_match_roll_c chunkmemset_safe_c inflate_fast_c slide_hash_c" ;;
+              march-x86-64-v4)
+                # psABI x86-64-v4 does NOT include PCLMUL/AES-NI; braid/chorba
+                # remain legitimately built. SSSE3 (from v2) + SSE2 floor.
+                forbid="adler32_c adler32_copy_c compare256_c longest_match_c longest_match_roll_c chunkmemset_safe_c inflate_fast_c slide_hash_c" ;;
+              march-armv8-crc|march-armv8.2-sha3|mcpu-power9|march-la464)
+                forbid="crc32_braid crc32_copy_braid crc32_chorba crc32_copy_chorba adler32_c adler32_copy_c compare256_c longest_match_c longest_match_roll_c chunkmemset_safe_c inflate_fast_c slide_hash_c" ;;
+              march-rvv)
+                forbid="adler32_c adler32_copy_c compare256_c longest_match_c longest_match_roll_c chunkmemset_safe_c inflate_fast_c slide_hash_c" ;;
+              march-z13)
+                forbid="slide_hash_c" ;;
+            esac
+            if [ $ok = 1 ] && ! python3 .github/scripts/check_arch_symbols.py "$bd" "${TRIPLE}-nm" --forbid "$forbid"; then
+              fails="$fails ${cname}(symbols)"
+            fi
+            if [ $ok = 1 ] && ! python3 .github/scripts/check_native_dispatch.py . "$bd" "$CC"; then
+              fails="$fails ${cname}(dispatch)"
+            fi
+          done
+
+          # Findings surface as ::error:: annotations; the job is intentionally
+          # not failed (it's a diagnostic, not a gate). With the native_*
+          # guard in place every combo is clean; the cflags-only-march combo
+          # prints its EXPECTED link failure, documenting the C/C++
+          # ISA-symmetry constraint rather than flagging it.
+          echo "${{ matrix.arch }} done; flagged combinations:${fails:- none}"

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -55,27 +55,51 @@ void     slide_hash_c(deflate_state *s);
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // Generic fallbacks when no native implementation exists
 #  ifdef ADLER32_FALLBACK
-#    define native_adler32 adler32_c
-#    define native_adler32_copy adler32_copy_c
+#    ifndef native_adler32
+#      define native_adler32 adler32_c
+#    endif
+#    ifndef native_adler32_copy
+#      define native_adler32_copy adler32_copy_c
+#    endif
 #  endif
 #  ifdef CHUNKSET_FALLBACK
-#    define native_chunkmemset_safe chunkmemset_safe_c
-#    define native_inflate_fast inflate_fast_c
+#    ifndef native_chunkmemset_safe
+#      define native_chunkmemset_safe chunkmemset_safe_c
+#    endif
+#    ifndef native_inflate_fast
+#      define native_inflate_fast inflate_fast_c
+#    endif
 #  endif
 #  ifdef COMPARE256_FALLBACK
-#    define native_compare256 compare256_c
-#    define native_longest_match longest_match_c
-#    define native_longest_match_roll longest_match_roll_c
+#    ifndef native_compare256
+#      define native_compare256 compare256_c
+#    endif
+#    ifndef native_longest_match
+#      define native_longest_match longest_match_c
+#    endif
+#    ifndef native_longest_match_roll
+#      define native_longest_match_roll longest_match_roll_c
+#    endif
 #  endif
 #  ifdef CRC32_CHORBA_FALLBACK
-#    define native_crc32 crc32_chorba
-#    define native_crc32_copy crc32_copy_chorba
+#    ifndef native_crc32
+#      define native_crc32 crc32_chorba
+#    endif
+#    ifndef native_crc32_copy
+#      define native_crc32_copy crc32_copy_chorba
+#    endif
 #  elif defined(CRC32_BRAID_FALLBACK)
-#    define native_crc32 crc32_braid
-#    define native_crc32_copy crc32_copy_braid
+#    ifndef native_crc32
+#      define native_crc32 crc32_braid
+#    endif
+#    ifndef native_crc32_copy
+#      define native_crc32_copy crc32_copy_braid
+#    endif
 #  endif
 #  ifdef SLIDE_HASH_FALLBACK
-#    define native_slide_hash slide_hash_c
+#    ifndef native_slide_hash
+#      define native_slide_hash slide_hash_c
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
Cross-compiles the static lib + C++ consumers per arch under `WITH_*` combos (compile+link only, no qemu) and asserts the archive symbol table via `.github/scripts/check_arch_symbols.py` (consumer-reference self-check + expect/forbid). x86_64 expect/forbid filled from verified behavior; other arches run the self-check with expected lists left as maintainer TODO. Opened to exercise the new workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI to cross-build multiple architectures/configurations and validate produced static libraries.
  * Added build-time validation tooling that checks feature-gated symbol correctness, native-dispatch resolution, and runtime-detection consistency; CI surfaces errors for failing configs.

* **Behavior**
  * Broadened and made conditional the selection of CRC32 “braid” and chorba implementations so builds choose required or fallback variants per architecture and feature set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nmoinvaz/zlib-ng/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->